### PR TITLE
Clan hooks, hook fixes and requested hooks

### DIFF
--- a/resources/Hurtworld-itemv2.opj
+++ b/resources/Hurtworld-itemv2.opj
@@ -1,6 +1,6 @@
 {
   "Name": "Hurtworld",
-  "TargetDirectory": "C:\\Users\\pimmo\\Documents\\JoPiDev\\AltCom\\Oxide\\OxideGits\\Oxide.Patcher\\uMod.Patcher\\src\\bin\\Debug\\net45",
+  "TargetDirectory": "D:\\Servers\\Hurtworld-itemv2\\Hurtworld_Data\\Managed",
   "Manifests": [
     {
       "AssemblyName": "Assembly-CSharp.dll",

--- a/resources/Hurtworld-itemv2.opj
+++ b/resources/Hurtworld-itemv2.opj
@@ -2145,7 +2145,7 @@
         {
           "Type": "Simple",
           "Hook": {
-            "InjectionIndex": 26,
+            "InjectionIndex": 25,
             "ReturnBehavior": 1,
             "ArgumentBehavior": 2,
             "ArgumentString": null,
@@ -2171,7 +2171,7 @@
         {
           "Type": "Simple",
           "Hook": {
-            "InjectionIndex": 8,
+            "InjectionIndex": 7,
             "ReturnBehavior": 1,
             "ArgumentBehavior": 2,
             "ArgumentString": null,
@@ -2199,8 +2199,8 @@
           "Hook": {
             "InjectionIndex": 0,
             "ReturnBehavior": 0,
-            "ArgumentBehavior": 2,
-            "ArgumentString": null,
+            "ArgumentBehavior": 4,
+            "ArgumentString": "a0, a1.ConnectedSession",
             "HookTypeName": "Simple",
             "Name": "OnClanMemberAdded",
             "HookName": "OnClanMemberAdded",
@@ -2226,8 +2226,8 @@
           "Hook": {
             "InjectionIndex": 0,
             "ReturnBehavior": 0,
-            "ArgumentBehavior": 2,
-            "ArgumentString": null,
+            "ArgumentBehavior": 4,
+            "ArgumentString": "a0, a1.ConnectedSession",
             "HookTypeName": "Simple",
             "Name": "OnClanMemberRemoved",
             "HookName": "OnClanMemberRemoved",
@@ -2251,10 +2251,10 @@
         {
           "Type": "Simple",
           "Hook": {
-            "InjectionIndex": 16,
+            "InjectionIndex": 15,
             "ReturnBehavior": 1,
-            "ArgumentBehavior": 3,
-            "ArgumentString": null,
+            "ArgumentBehavior": 4,
+            "ArgumentString": "this, a0.ConnectedSession",
             "HookTypeName": "Simple",
             "Name": "OnClanMemberAdd",
             "HookName": "OnClanMemberAdd",
@@ -2277,10 +2277,10 @@
         {
           "Type": "Simple",
           "Hook": {
-            "InjectionIndex": 17,
+            "InjectionIndex": 16,
             "ReturnBehavior": 1,
-            "ArgumentBehavior": 3,
-            "ArgumentString": null,
+            "ArgumentBehavior": 4,
+            "ArgumentString": "this, a0.ConnectedSession",
             "HookTypeName": "Simple",
             "Name": "OnClanMemberRemove",
             "HookName": "OnClanMemberRemove",
@@ -2303,7 +2303,7 @@
         {
           "Type": "Simple",
           "Hook": {
-            "InjectionIndex": 43,
+            "InjectionIndex": 42,
             "ReturnBehavior": 0,
             "ArgumentBehavior": 2,
             "ArgumentString": null,
@@ -2329,7 +2329,7 @@
         {
           "Type": "Simple",
           "Hook": {
-            "InjectionIndex": 30,
+            "InjectionIndex": 29,
             "ReturnBehavior": 0,
             "ArgumentBehavior": 2,
             "ArgumentString": null,
@@ -2372,6 +2372,273 @@
               "Parameters": []
             },
             "MSILHash": "RSi3/R92YZEqdE8e8upU9nTIHGc5CDNWko8yt5KPEvU=",
+            "BaseHookName": null,
+            "HookCategory": "Events"
+          }
+        },
+        {
+          "Type": "Simple",
+          "Hook": {
+            "InjectionIndex": 86,
+            "ReturnBehavior": 0,
+            "ArgumentBehavior": 4,
+            "ArgumentString": "this, a0.ConnectedSession, a1",
+            "HookTypeName": "Simple",
+            "Name": "OnPlayerAuthorized",
+            "HookName": "OnPlayerAuthorized",
+            "AssemblyName": "Assembly-CSharp.dll",
+            "TypeName": "OwnershipStakeServer",
+            "Flagged": false,
+            "Signature": {
+              "Exposure": 2,
+              "Name": "Authorize",
+              "ReturnType": "System.Void",
+              "Parameters": [
+                "PlayerIdentity",
+                "UnityEngine.GameObject"
+              ]
+            },
+            "MSILHash": "k8Q/YFOI4kxpw0HbxXFXpPHlswF2QJ3dhTLbnzjUYp8=",
+            "BaseHookName": "OnPlayerAuthorize",
+            "HookCategory": "Player"
+          }
+        },
+        {
+          "Type": "Simple",
+          "Hook": {
+            "InjectionIndex": 0,
+            "ReturnBehavior": 1,
+            "ArgumentBehavior": 4,
+            "ArgumentString": "this, a0.ConnectedSession, a1",
+            "HookTypeName": "Simple",
+            "Name": "OnPlayerDeauthorize",
+            "HookName": "OnPlayerDeauthorize",
+            "AssemblyName": "Assembly-CSharp.dll",
+            "TypeName": "OwnershipStakeServer",
+            "Flagged": false,
+            "Signature": {
+              "Exposure": 2,
+              "Name": "Deauthorize",
+              "ReturnType": "System.Void",
+              "Parameters": [
+                "PlayerIdentity",
+                "UnityEngine.GameObject"
+              ]
+            },
+            "MSILHash": "ZHUeh4GLQb46j4a7UCydNSSVi2qfQm/4v3xdU1BSaP8=",
+            "BaseHookName": null,
+            "HookCategory": "Player"
+          }
+        },
+        {
+          "Type": "Simple",
+          "Hook": {
+            "InjectionIndex": 51,
+            "ReturnBehavior": 0,
+            "ArgumentBehavior": 4,
+            "ArgumentString": "this, a0.ConnectedSession, a1",
+            "HookTypeName": "Simple",
+            "Name": "OnPlayerDeauthorized",
+            "HookName": "OnPlayerDeauthorized",
+            "AssemblyName": "Assembly-CSharp.dll",
+            "TypeName": "OwnershipStakeServer",
+            "Flagged": false,
+            "Signature": {
+              "Exposure": 2,
+              "Name": "Deauthorize",
+              "ReturnType": "System.Void",
+              "Parameters": [
+                "PlayerIdentity",
+                "UnityEngine.GameObject"
+              ]
+            },
+            "MSILHash": "ZHUeh4GLQb46j4a7UCydNSSVi2qfQm/4v3xdU1BSaP8=",
+            "BaseHookName": "OnPlayerDeauthorize",
+            "HookCategory": "Player"
+          }
+        },
+        {
+          "Type": "Simple",
+          "Hook": {
+            "InjectionIndex": 66,
+            "ReturnBehavior": 1,
+            "ArgumentBehavior": 4,
+            "ArgumentString": "this, l0.ConnectedSession",
+            "HookTypeName": "Simple",
+            "Name": "OnClanMemberApply",
+            "HookName": "OnClanMemberApply",
+            "AssemblyName": "Assembly-CSharp.dll",
+            "TypeName": "Clan",
+            "Flagged": false,
+            "Signature": {
+              "Exposure": 2,
+              "Name": "RPCSubmitApplication",
+              "ReturnType": "System.Void",
+              "Parameters": [
+                "uLink.NetworkMessageInfo"
+              ]
+            },
+            "MSILHash": "YXL+qZZuW5zWCSOkV6wburNK1wyEjGiLhnrYQ4nYPMI=",
+            "BaseHookName": null,
+            "HookCategory": "Clan"
+          }
+        },
+        {
+          "Type": "Simple",
+          "Hook": {
+            "InjectionIndex": 135,
+            "ReturnBehavior": 0,
+            "ArgumentBehavior": 4,
+            "ArgumentString": "this, l0.ConnectedSession",
+            "HookTypeName": "Simple",
+            "Name": "OnClanMemberApplied",
+            "HookName": "OnClanMemberApplied",
+            "AssemblyName": "Assembly-CSharp.dll",
+            "TypeName": "Clan",
+            "Flagged": false,
+            "Signature": {
+              "Exposure": 2,
+              "Name": "RPCSubmitApplication",
+              "ReturnType": "System.Void",
+              "Parameters": [
+                "uLink.NetworkMessageInfo"
+              ]
+            },
+            "MSILHash": "YXL+qZZuW5zWCSOkV6wburNK1wyEjGiLhnrYQ4nYPMI=",
+            "BaseHookName": "OnClanMemberApply",
+            "HookCategory": "Clan"
+          }
+        },
+        {
+          "Type": "Simple",
+          "Hook": {
+            "InjectionIndex": 146,
+            "ReturnBehavior": 1,
+            "ArgumentBehavior": 4,
+            "ArgumentString": "this, l3.ConnectedSession",
+            "HookTypeName": "Simple",
+            "Name": "OnClanMemberPromote",
+            "HookName": "OnClanMemberPromote",
+            "AssemblyName": "Assembly-CSharp.dll",
+            "TypeName": "Clan",
+            "Flagged": false,
+            "Signature": {
+              "Exposure": 2,
+              "Name": "RPCPromoteToOfficer",
+              "ReturnType": "System.Void",
+              "Parameters": [
+                "System.UInt64",
+                "uLink.NetworkMessageInfo"
+              ]
+            },
+            "MSILHash": "Twfkmz+C+k5TL8FiNqS0yBwYRKgOfkqENwUudOGXtfQ=",
+            "BaseHookName": null,
+            "HookCategory": "Clan"
+          }
+        },
+        {
+          "Type": "Simple",
+          "Hook": {
+            "InjectionIndex": 174,
+            "ReturnBehavior": 0,
+            "ArgumentBehavior": 4,
+            "ArgumentString": "this, l3.ConnectedSession",
+            "HookTypeName": "Simple",
+            "Name": "OnClanMemberPromoted",
+            "HookName": "OnClanMemberPromoted",
+            "AssemblyName": "Assembly-CSharp.dll",
+            "TypeName": "Clan",
+            "Flagged": false,
+            "Signature": {
+              "Exposure": 2,
+              "Name": "RPCPromoteToOfficer",
+              "ReturnType": "System.Void",
+              "Parameters": [
+                "System.UInt64",
+                "uLink.NetworkMessageInfo"
+              ]
+            },
+            "MSILHash": "Twfkmz+C+k5TL8FiNqS0yBwYRKgOfkqENwUudOGXtfQ=",
+            "BaseHookName": "OnClanMemberPromote",
+            "HookCategory": "Clan"
+          }
+        },
+        {
+          "Type": "Simple",
+          "Hook": {
+            "InjectionIndex": 146,
+            "ReturnBehavior": 1,
+            "ArgumentBehavior": 4,
+            "ArgumentString": "this, l3.ConnectedSession",
+            "HookTypeName": "Simple",
+            "Name": "OnClanMemberDemote",
+            "HookName": "OnClanMemberDemote",
+            "AssemblyName": "Assembly-CSharp.dll",
+            "TypeName": "Clan",
+            "Flagged": false,
+            "Signature": {
+              "Exposure": 2,
+              "Name": "RPCDemoteToRecruit",
+              "ReturnType": "System.Void",
+              "Parameters": [
+                "System.UInt64",
+                "uLink.NetworkMessageInfo"
+              ]
+            },
+            "MSILHash": "7HKrekueXmHuIJT3GGEHo2jKu2RR1tv+Qq6hCY/LBS4=",
+            "BaseHookName": null,
+            "HookCategory": "Clan"
+          }
+        },
+        {
+          "Type": "Simple",
+          "Hook": {
+            "InjectionIndex": 174,
+            "ReturnBehavior": 0,
+            "ArgumentBehavior": 4,
+            "ArgumentString": "this, l3.ConnectedSession",
+            "HookTypeName": "Simple",
+            "Name": "OnClanMemberDemoted",
+            "HookName": "OnClanMemberDemoted",
+            "AssemblyName": "Assembly-CSharp.dll",
+            "TypeName": "Clan",
+            "Flagged": false,
+            "Signature": {
+              "Exposure": 2,
+              "Name": "RPCDemoteToRecruit",
+              "ReturnType": "System.Void",
+              "Parameters": [
+                "System.UInt64",
+                "uLink.NetworkMessageInfo"
+              ]
+            },
+            "MSILHash": "7HKrekueXmHuIJT3GGEHo2jKu2RR1tv+Qq6hCY/LBS4=",
+            "BaseHookName": "OnClanMemberDemote",
+            "HookCategory": "Clan"
+          }
+        },
+        {
+          "Type": "Simple",
+          "Hook": {
+            "InjectionIndex": 46,
+            "ReturnBehavior": 0,
+            "ArgumentBehavior": 4,
+            "ArgumentString": "l0, a0, l3",
+            "HookTypeName": "Simple",
+            "Name": "OnTerritoryPointsClaimed",
+            "HookName": "OnTerritoryPointsClaimed",
+            "AssemblyName": "Assembly-CSharp.dll",
+            "TypeName": "TerritoryControlMarker",
+            "Flagged": false,
+            "Signature": {
+              "Exposure": 2,
+              "Name": "ClaimPoints",
+              "ReturnType": "System.Void",
+              "Parameters": [
+                "uLink.NetworkMessageInfo"
+              ]
+            },
+            "MSILHash": "KmD+nr7MKUo2JD/U9Sh9+YMpXNXocnVwvOlmIf0Bm2Q=",
             "BaseHookName": null,
             "HookCategory": "Events"
           }

--- a/resources/Hurtworld-itemv2.opj
+++ b/resources/Hurtworld-itemv2.opj
@@ -1,6 +1,6 @@
 {
   "Name": "Hurtworld",
-  "TargetDirectory": "D:\\Servers\\Hurtworld-itemv2\\Hurtworld_Data\\Managed",
+  "TargetDirectory": "C:\\Users\\pimmo\\Documents\\JoPiDev\\AltCom\\Oxide\\OxideGits\\Oxide.Patcher\\uMod.Patcher\\src\\bin\\Debug\\net45",
   "Manifests": [
     {
       "AssemblyName": "Assembly-CSharp.dll",
@@ -1390,7 +1390,7 @@
             "InjectionIndex": 0,
             "ReturnBehavior": 1,
             "ArgumentBehavior": 4,
-            "ArgumentString": "a0.ConnectedSession, a1",
+            "ArgumentString": "this, a0.ConnectedSession, a1",
             "HookTypeName": "Simple",
             "Name": "OnPlayerAuthorize",
             "HookName": "OnPlayerAuthorize",
@@ -2140,6 +2140,240 @@
             "MSILHash": "2bWUJiWLVUbUHituF9UwX0521oD/bVZBfAFghsIEyg4=",
             "BaseHookName": "OnPlayerRespawn",
             "HookCategory": "Player"
+          }
+        },
+        {
+          "Type": "Simple",
+          "Hook": {
+            "InjectionIndex": 26,
+            "ReturnBehavior": 1,
+            "ArgumentBehavior": 2,
+            "ArgumentString": null,
+            "HookTypeName": "Simple",
+            "Name": "OnClanRegister",
+            "HookName": "OnClanRegister",
+            "AssemblyName": "Assembly-CSharp.dll",
+            "TypeName": "ClanManager",
+            "Flagged": false,
+            "Signature": {
+              "Exposure": 2,
+              "Name": "RegisterClan",
+              "ReturnType": "System.Boolean",
+              "Parameters": [
+                "Clan"
+              ]
+            },
+            "MSILHash": "9oDpEl7uBbSo900OI40n+uW02vDfnFA9My/gFJyiamg=",
+            "BaseHookName": null,
+            "HookCategory": "Clan"
+          }
+        },
+        {
+          "Type": "Simple",
+          "Hook": {
+            "InjectionIndex": 8,
+            "ReturnBehavior": 1,
+            "ArgumentBehavior": 2,
+            "ArgumentString": null,
+            "HookTypeName": "Simple",
+            "Name": "OnClanDisband",
+            "HookName": "OnClanDisband",
+            "AssemblyName": "Assembly-CSharp.dll",
+            "TypeName": "ClanManager",
+            "Flagged": false,
+            "Signature": {
+              "Exposure": 2,
+              "Name": "DisbandClan",
+              "ReturnType": "System.Void",
+              "Parameters": [
+                "Clan"
+              ]
+            },
+            "MSILHash": "dMMXrS1U9r0NV1zFSj2xtqjz95pJopPm+Xd6kNlJckw=",
+            "BaseHookName": null,
+            "HookCategory": "Clan"
+          }
+        },
+        {
+          "Type": "Simple",
+          "Hook": {
+            "InjectionIndex": 0,
+            "ReturnBehavior": 0,
+            "ArgumentBehavior": 2,
+            "ArgumentString": null,
+            "HookTypeName": "Simple",
+            "Name": "OnClanMemberAdded",
+            "HookName": "OnClanMemberAdded",
+            "AssemblyName": "Assembly-CSharp.dll",
+            "TypeName": "ClanManager",
+            "Flagged": false,
+            "Signature": {
+              "Exposure": 2,
+              "Name": "NotifyOnClanMemberAdded",
+              "ReturnType": "System.Void",
+              "Parameters": [
+                "Clan",
+                "PlayerIdentity"
+              ]
+            },
+            "MSILHash": "zr8seSnXyt7jAqTqV+oa3EmLetyGN8HN5M4ChTh+k7Y=",
+            "BaseHookName": null,
+            "HookCategory": "Clan"
+          }
+        },
+        {
+          "Type": "Simple",
+          "Hook": {
+            "InjectionIndex": 0,
+            "ReturnBehavior": 0,
+            "ArgumentBehavior": 2,
+            "ArgumentString": null,
+            "HookTypeName": "Simple",
+            "Name": "OnClanMemberRemoved",
+            "HookName": "OnClanMemberRemoved",
+            "AssemblyName": "Assembly-CSharp.dll",
+            "TypeName": "ClanManager",
+            "Flagged": false,
+            "Signature": {
+              "Exposure": 2,
+              "Name": "NotifyOnClanMemberRemoved",
+              "ReturnType": "System.Void",
+              "Parameters": [
+                "Clan",
+                "PlayerIdentity"
+              ]
+            },
+            "MSILHash": "tlWwPpQTFXPAXaQg/F8oiBAcuZB/g2xIIneYuYf3qcA=",
+            "BaseHookName": null,
+            "HookCategory": "Clan"
+          }
+        },
+        {
+          "Type": "Simple",
+          "Hook": {
+            "InjectionIndex": 16,
+            "ReturnBehavior": 1,
+            "ArgumentBehavior": 3,
+            "ArgumentString": null,
+            "HookTypeName": "Simple",
+            "Name": "OnClanMemberAdd",
+            "HookName": "OnClanMemberAdd",
+            "AssemblyName": "Assembly-CSharp.dll",
+            "TypeName": "Clan",
+            "Flagged": false,
+            "Signature": {
+              "Exposure": 2,
+              "Name": "AddMember",
+              "ReturnType": "System.Boolean",
+              "Parameters": [
+                "PlayerIdentity"
+              ]
+            },
+            "MSILHash": "QbtPH0sHJ0zISHAX8JGBFeqUm72hnXwGE36zVQcOD+I=",
+            "BaseHookName": null,
+            "HookCategory": "Clan"
+          }
+        },
+        {
+          "Type": "Simple",
+          "Hook": {
+            "InjectionIndex": 17,
+            "ReturnBehavior": 1,
+            "ArgumentBehavior": 3,
+            "ArgumentString": null,
+            "HookTypeName": "Simple",
+            "Name": "OnClanMemberRemove",
+            "HookName": "OnClanMemberRemove",
+            "AssemblyName": "Assembly-CSharp.dll",
+            "TypeName": "Clan",
+            "Flagged": false,
+            "Signature": {
+              "Exposure": 2,
+              "Name": "RemoveMember",
+              "ReturnType": "System.Void",
+              "Parameters": [
+                "PlayerIdentity"
+              ]
+            },
+            "MSILHash": "uZU+QUqFFFDu/fWoKBPOiWuH+QeS7z2UgBVn9YAr2UI=",
+            "BaseHookName": null,
+            "HookCategory": "Clan"
+          }
+        },
+        {
+          "Type": "Simple",
+          "Hook": {
+            "InjectionIndex": 43,
+            "ReturnBehavior": 0,
+            "ArgumentBehavior": 2,
+            "ArgumentString": null,
+            "HookTypeName": "Simple",
+            "Name": "OnClanRegistered",
+            "HookName": "OnClanRegistered",
+            "AssemblyName": "Assembly-CSharp.dll",
+            "TypeName": "ClanManager",
+            "Flagged": false,
+            "Signature": {
+              "Exposure": 2,
+              "Name": "RegisterClan",
+              "ReturnType": "System.Boolean",
+              "Parameters": [
+                "Clan"
+              ]
+            },
+            "MSILHash": "9oDpEl7uBbSo900OI40n+uW02vDfnFA9My/gFJyiamg=",
+            "BaseHookName": "OnClanRegister",
+            "HookCategory": "Clan"
+          }
+        },
+        {
+          "Type": "Simple",
+          "Hook": {
+            "InjectionIndex": 30,
+            "ReturnBehavior": 0,
+            "ArgumentBehavior": 2,
+            "ArgumentString": null,
+            "HookTypeName": "Simple",
+            "Name": "OnClanDisbanded",
+            "HookName": "OnClanDisbanded",
+            "AssemblyName": "Assembly-CSharp.dll",
+            "TypeName": "ClanManager",
+            "Flagged": false,
+            "Signature": {
+              "Exposure": 2,
+              "Name": "DisbandClan",
+              "ReturnType": "System.Void",
+              "Parameters": [
+                "Clan"
+              ]
+            },
+            "MSILHash": "dMMXrS1U9r0NV1zFSj2xtqjz95pJopPm+Xd6kNlJckw=",
+            "BaseHookName": "OnClanDisband",
+            "HookCategory": "Clan"
+          }
+        },
+        {
+          "Type": "Simple",
+          "Hook": {
+            "InjectionIndex": 22,
+            "ReturnBehavior": 0,
+            "ArgumentBehavior": 4,
+            "ArgumentString": "this, l0",
+            "HookTypeName": "Simple",
+            "Name": "OnExplode",
+            "HookName": "OnExplode",
+            "AssemblyName": "Assembly-CSharp.dll",
+            "TypeName": "ExplosiveDynamicServer",
+            "Flagged": false,
+            "Signature": {
+              "Exposure": 2,
+              "Name": "ExplodeNoDestroy",
+              "ReturnType": "System.Void",
+              "Parameters": []
+            },
+            "MSILHash": "RSi3/R92YZEqdE8e8upU9nTIHGc5CDNWko8yt5KPEvU=",
+            "BaseHookName": null,
+            "HookCategory": "Events"
           }
         }
       ],


### PR DESCRIPTION
# Newly added hooks
## Clan

### OnClanRegister
- Called when a new clan about to be registered.
- Returning a non-null value overrides default behavior.
```cs
void OnClanRegister(Clan clan)
{
  Puts("OnClanRegister works!");
}
```

### OnClanRegistered
- Called when a new clan is registered
- No return behavior.
```cs
void OnClanRegistered(Clan clan)
{
  Puts("OnClanRegister works!");
}
```

### OnClanDisband
- Called when a clan is about to be disbanded.
- Returning a non-null value overrides default behavior.
```cs
void OnClanDisband(Clan clan)
{
  Puts("OnClanDisband works!");
}
```

### OnClanDisbanded
- Called when a clan is disbanded.
- No return behavior.
```cs
void OnClanDisbanded(Clan clan)
{
  Puts("OnClanDisbanded works!");
}
```

### OnClanMemberAdd
- Called when player is about to be added to a clan.
- Returning a non-null value overrides default behavior.
```cs
void OnClanMemberAdd(Clan clan, PlayerSession session)
{
  Puts("OnClanMemberAdd works!");
}
```

### OnClanMemberAdded
- Called when a player is added to a clan.
- No return behavior.
```cs
void OnClanMemberAdded(Clan clan, PlayerSession session)
{
  Puts("OnClanMemberAdded works!");
}
```

### OnClanMemberRemove
- Called when a clan member is about to be removed.
- Returning a non-null value overrides default behavior.
```cs
void OnClanMemberRemove(Clan clan, PlayerSession session)
{
  Puts("OnClanMemberRemove works!");
}
```

### OnClanMemberRemoved
- Called when a clan member is removed.
- No return behavior.
```cs
void OnClanMemberRemoved(Clan clan, PlayerSession session)
{
  Puts("OnClanMemberRemoved works!");
}
```

### OnClanMemberApply
- Called when a player applies to a clan.
- Returning a non-null value overrides default behavior.
```cs
void OnClanMemberApply(Clan clan, PlayerSession session)
{
  Puts ("OnClanMemberApply works!");
}
```

### OnClanMemberApplied
- Called when a player applied to a clan.
- No return behavior.
```cs
void OnClanMemberApplied(Clan clan, PlayerSession session)
{
  Puts ("OnClanMemberApplied works!");
}
```

### OnClanMemberPromote
- Called when a clan member is about t be promoted.
- Returning a non-null value overrides default behavior.
```cs
void OnClanMemberPromote(Clan clan, PlayerSession session)
{
  Puts ("OnClanMemberPromote works!");
}
```

### OnClanMemberPromoted
- Called when a clan member is promoted.
- No return behavior.
```cs
void OnClanMemberPromoted(Clan clan, PlayerSession session)
{
  Puts ("OnClanMemberPromoted works!");
}
```

### OnClanMemberDemote
- Called when a clan member is about to be demoted
- Returning a non-null value overrides default behavior.
```cs
void OnClanMemberDemote(Clan clan, PlayerSession session)
{
  Puts ("OnClanMemberDemote works!");
}
```

### OnClanMemberDemoted
- Called when a clan member is demoted.
- No return behavior.
```cs
void OnClanMemberDemoted(Clan clan, PlayerSession session)
{
  Puts ("OnClanMemberDemoted works!");
}
```


## Events
### OnTerritoryPointsClaimed
- Called when Territory points are claimed.
- No return behavior.
```cs
void OnTerritoryPointsClaimed(Clan clan, uLink.NetworkMessageInfo info, int points)
{
  Puts ("OnTerritoryPointsClaimed works!");
}
```

### OnExplode
- Called when an explosion happens.
- No return behavior.
```cs
void OnExplode(ExplosiveDynamicServer exposive, GameObject obj)
{
  Puts ("OnExplode works!");
}
```


## Player
### OnPlayerAuthorized
- Called when a player gets authorized to a stake.
- No return behavior.
```cs
void OnPlayerAuthorized(OwnershipStakeServer Stake, PlayerSession session, GameObject ownerEntity)
{
  Puts ("OnPlayerAuthorized works!");
}
```

### OnPlayerDeauthorize
- Called when a player is about to be deauthorized from a stake.
- Returning a non-null value overrides default behavior.
```cs
void OnPlayerDeauthorize(OwnershipStakeServer Stake, PlayerSession session, GameObject ownerEntity)
{
  Puts ("OnPlayerDeauthorize works!");
}
```

### OnPlayerDeauthorized
- Called when a player is deauthorized from a stake.
- No return behavior.
```cs
void OnPlayerDeauthorized(OwnershipStakeServer Stake, PlayerSession session, GameObject ownerEntity)
{
  Puts ("OnPlayerDeauthorized works!");
}
```


# Updated hooks
### OnPlayerAuthorize
Old: 
```cs
OnPlayerAuthorize(PlayerSession session, GameObject ownerEntity)
```

New: 
```cs
OnPlayerAuthorize(OwnershipStakeServer Stake, PlayerSession session, GameObject ownerEntity)
```