### PR TITLE
Added OnClanTerritoryClaimBroadcast hook

### DIFF
--- a/resources/Hurtworld.opj
+++ b/resources/Hurtworld.opj
@@ -26,7 +26,7 @@
                 "System.String"
               ]
             },
-            "MSILHash": "v/ykGl+kfAFzpRCtdfErjDwNujuKBSHBRFzaXb1Q550=",
+            "MSILHash": "VTQAuuYpcB/JD/lzO/IdRVgnosw9cfqL0ytNRKLXsyc=",
             "BaseHookName": null,
             "HookCategory": "Server"
           }
@@ -300,7 +300,7 @@
                 "System.String"
               ]
             },
-            "MSILHash": "v/ykGl+kfAFzpRCtdfErjDwNujuKBSHBRFzaXb1Q550=",
+            "MSILHash": "VTQAuuYpcB/JD/lzO/IdRVgnosw9cfqL0ytNRKLXsyc=",
             "BaseHookName": "IOnServerCommand [internal]",
             "HookCategory": "_Patches"
           }
@@ -2920,6 +2920,57 @@
             "MSILHash": "B1KjdiKWSc4FGvqp8ePg8RBD1uwxelP38Ta+9J7N6v4=",
             "BaseHookName": "OnItemMutatorApplied",
             "HookCategory": "Item"
+          }
+        },
+        {
+          "Type": "Modify",
+          "Hook": {
+            "InjectionIndex": 0,
+            "RemoveCount": 14,
+            "Instructions": [],
+            "HookTypeName": "Modify",
+            "Name": "IOnClanTerritoryClaimBroadcast",
+            "HookName": "IOnClanTerritoryClaimBroadcast",
+            "AssemblyName": "Assembly-CSharp.dll",
+            "TypeName": "TerritoryControlMarker",
+            "Flagged": false,
+            "Signature": {
+              "Exposure": 0,
+              "Name": "OnClanAuthorized",
+              "ReturnType": "System.Void",
+              "Parameters": [
+                "Clan"
+              ]
+            },
+            "MSILHash": "Sy2xffDRwPDD0Br6g5L2rYRc/OVJtykZgb3r9IOfhTs=",
+            "BaseHookName": null,
+            "HookCategory": "_Patches"
+          }
+        },
+        {
+          "Type": "Simple",
+          "Hook": {
+            "InjectionIndex": 0,
+            "ReturnBehavior": 0,
+            "ArgumentBehavior": 3,
+            "ArgumentString": null,
+            "HookTypeName": "Simple",
+            "Name": "IOnClanTerritoryClaimBroadcast",
+            "HookName": "IOnClanTerritoryClaimBroadcast",
+            "AssemblyName": "Assembly-CSharp.dll",
+            "TypeName": "TerritoryControlMarker",
+            "Flagged": false,
+            "Signature": {
+              "Exposure": 0,
+              "Name": "OnClanAuthorized",
+              "ReturnType": "System.Void",
+              "Parameters": [
+                "Clan"
+              ]
+            },
+            "MSILHash": "Sy2xffDRwPDD0Br6g5L2rYRc/OVJtykZgb3r9IOfhTs=",
+            "BaseHookName": null,
+            "HookCategory": "Events"
           }
         }
       ],

--- a/src/HurtworldHooks.cs
+++ b/src/HurtworldHooks.cs
@@ -38,6 +38,25 @@ namespace Oxide.Game.Hurtworld
 
         #endregion Clan Hooks
 
+        #region Event Hooks
+
+        /// <summary>
+        /// Called when territory claim messages is broadcasted to chat
+        /// </summary>
+        /// <param name="territoryMarker"></param>
+        /// <param name="clan"></param>
+        [HookMethod("IOnClanTerritoryClaimBroadcast")]
+        private void IOnClanTerritoryClaimBroadcast(TerritoryControlMarker territoryMarker, Clan clan)
+        {
+            object shouldBroadcast = Interface.CallHook("OnClanTerritoryClaimBroadcast", territoryMarker, clan);
+            if (shouldBroadcast == null)
+            {
+                Singleton<ChatManagerServer>.Instance.SendChatMessage(new ServerChatMessage("Territory " + territoryMarker.Stake.TerritoryName + " has been claimed by " + clan.ClanName, Color.magenta, true));
+            }
+        }
+
+        #endregion Event Hooks
+
         #region Player Hooks
 
         /// <summary>


### PR DESCRIPTION
Hook gets called when clan claims a territory control point.
```cs
object OnClanTerritoryClaimBroadcast(TerritoryControlMarker controlMarker, Clan clan)
{
  Puts("OnClanTerritoryClaimBroadcast works!");
  return null;
}
```